### PR TITLE
chore: bump React Query version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.21.0",
     "@stripe/stripe-react-native": "0.38.3",
-    "@tanstack/react-query": "5.51.7",
+    "@tanstack/react-query": "5.90.2",
     "@trpc/client": "11.0.0-next-beta.234",
     "@trpc/react-query": "11.0.0-next-beta.234",
     "axios": "1.6.8",


### PR DESCRIPTION
## Summary
- update @tanstack/react-query to version 5.90.2 in the Expo app package configuration

## Testing
- pnpm install *(fails: registry.npmjs.org returned 403 Forbidden for expo-localization)*
- pnpm dev *(fails: expo CLI not available because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d67600ac83288bbfbc30029e76da