### PR TITLE
Add tailwindcss dev dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
     "@types/react": "18.2.79",
     "@types/react-native": "0.73.0",
     "eslint": "8.57.0",
+    "tailwindcss": "^3.4.3",
     "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- add `tailwindcss` to the Expo app's development dependencies

## Testing
- pnpm install *(fails: registry.npmjs.org returned 403 due to missing auth in this environment)*
- pnpm expo start --offline *(fails: Expo CLI is unavailable because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e1dc1b25288328a97108c3fe66cc00