### PR TITLE
Handle blank secrets in environment config

### DIFF
--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,25 +1,31 @@
 import 'dotenv/config';
-import { z } from 'zod';
+import { z, type ZodTypeAny } from 'zod';
+
+const emptyStringToUndefined = <T extends ZodTypeAny>(schema: T) =>
+  z.preprocess((value) => {
+    if (typeof value === 'string' && value.trim() === '') {
+      return undefined;
+    }
+
+    return value;
+  }, schema);
 
 const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().default(3000),
   DATABASE_URL: z.string().url(),
-  SMSRU_API_KEY: z.string().min(1).default('demo-sms-key'),
-  JWT_ACCESS_SECRET: z
-    .string()
-    .min(32)
-    .default('0123456789abcdef0123456789abcdef'),
-  JWT_REFRESH_SECRET: z
-    .string()
-    .min(32)
-    .default('fedcba9876543210fedcba9876543210'),
+  SMSRU_API_KEY: emptyStringToUndefined(z.string().min(1).default('demo-sms-key')),
+  JWT_ACCESS_SECRET: emptyStringToUndefined(
+    z.string().min(32).default('0123456789abcdef0123456789abcdef')
+  ),
+  JWT_REFRESH_SECRET: emptyStringToUndefined(
+    z.string().min(32).default('fedcba9876543210fedcba9876543210')
+  ),
   JWT_ACCESS_TTL: z.string().default('15m'),
   JWT_REFRESH_TTL: z.string().default('30d'),
-  REFRESH_TOKEN_SALT: z
-    .string()
-    .min(16)
-    .default('unique-device-salt'),
+  REFRESH_TOKEN_SALT: emptyStringToUndefined(
+    z.string().min(16).default('unique-device-salt')
+  ),
   RATE_LIMIT_WINDOW: z.coerce.number().default(60000),
   RATE_LIMIT_MAX: z.coerce.number().default(5),
   STRIPE_PUBLISHABLE_KEY: z.string().optional(),
@@ -29,7 +35,7 @@ const envSchema = z.object({
     .string()
     .url()
     .default('https://example.com'),
-  ADMIN_DEFAULT_PASSWORD: z.string().min(4).default('1234')
+  ADMIN_DEFAULT_PASSWORD: emptyStringToUndefined(z.string().min(4).default('1234'))
 });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- add a reusable helper that normalizes empty environment strings before validation
- allow secret environment variables with defaults to fall back when blanks are provided

## Testing
- pnpm --filter codex-server prisma:seed *(fails: missing dependencies/tsx not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ec71bee8832897bcc0c8fe8fe8ef